### PR TITLE
Fix for output without style, add spaces after function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,11 @@ Solves the problem and returns an object.
     - `initial` - Boolean - print the problem (default: false)
     - `style` - Boolean - format the output (default: false)
 
-### `solve (options).toString(style)`
+### `solve (options).toString()`
 Converts the solution to string.
 
-  - `@style` - Boolean - if true, the stringified solution will be styled.
-
-### `solve (options).printSolution(style)`
+### `solve (options).printSolution()`
 Prints the stringified solution in terminal.
-
-  - `@style` - Boolean - if true, the stringified solution will be styled.
 
 ## Specs
 
@@ -92,6 +88,8 @@ There is an example in test foloder `1.js`. Run it with `node test/1.js`
 
 ## Changelog
 
+  - `0.0.3`:
+    - Fix for output without style
   - `0.0.2`:
     - Release to npmjs
     - Return an object ([#3] (https://github.com/radubogdan/sudoku-solver/issues/3))

--- a/index.js
+++ b/index.js
@@ -8,17 +8,17 @@ var sudokuSolver = {};
 // Run specs for this functions using jasmine
 //
 // Check if i is on the same row with j
-global.sameRow = function(i, j) {
+global.sameRow = function (i, j) {
     return (Math.floor(i/9) == Math.floor(j/9));
 }
 
 // Check if i is on the same column with j
-global.sameColumn = function(i, j) {
+global.sameColumn = function (i, j) {
     return ((i - j) % 9 == 0);
 }
 
 // Check if i is in the same block with j
-global.sameBlock = function(i, j) {
+global.sameBlock = function (i, j) {
     return (Math.floor(i/27) == Math.floor(j/27) && Math.floor(i%9/3) == Math.floor(j%9/3));
 }
 
@@ -50,7 +50,7 @@ function stylishOutput(problem) {
 }
 
 // Output the problem in the terminal
-global.output = function(problem, style, doNotPrint) {
+global.output = function (problem, style, doNotPrint) {
 
     // Check if style is false or true
     var stringifiedSolution = style == false ? problem : stylishOutput(problem);
@@ -138,11 +138,11 @@ sudokuSolver.solve = function (options) {
     solver(problem);
 
     return {
-        toString: function(style) {
+        toString: function () {
             // We just return the stringified solution (styled or not)
             return output (_solution, style, true)
         }
-      , printSolution: function (style) {
+      , printSolution: function () {
 
             // Print in terminal the solution
             output (_solution, style)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sudoku-solver",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Solve sudoku problems using Node.js and output the solution in the terminal",
   "main": "index.js",
   "dependencies": {
@@ -25,6 +25,10 @@
     {
         "name": "Ionică Bizău",
         "email": "bizauionica@gmail.com"
+    },
+    {
+        "name": "@ffflorian",
+        "email": ""
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
The unstyled output didn't work. It always returned the styled version, regardless of the `style: true` setting, because `style` was set in the `toString()` and `printSolution()` functions, overwriting `style` from the options.

Example:

``` js
SudokuSolver.solve({
    problem: sudoku,
    style: true,
    initial: false
}).printSolution();
```

returned the same as

``` js
SudokuSolver.solve({
    problem: sudoku,
    style: false,
    initial: false
}).printSolution();
```

It worked only when I executed

``` js
SudokuSolver.solve({
    problem: sudoku,
    style: false,
    initial: false
}).printSolution(false);
```

Which seemed quite wrong :wink: 
